### PR TITLE
Export empty value for Password Hashes

### DIFF
--- a/drivers/ImportDriver_memberpassword.php
+++ b/drivers/ImportDriver_memberpassword.php
@@ -43,6 +43,6 @@ class ImportDriver_memberpassword extends ImportDriver_default
      */
     public function export($data, $entry_id = null)
     {
-        return trim($data['password']);
+        return '';
     }
 }


### PR DESCRIPTION
Adding Password Hashes to the Export CSV is risky. Even it may not be easy to crack the password it's still possible for someone to find out that. Suggest not to include that as the default.